### PR TITLE
Add desktop app for trending topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,16 +1,60 @@
-### Hi there 👋
+# 网络热点话题收集工具
 
-<!--
-**alan721/alan721** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+一个开箱即用的小软件，可以自动从百度实时热点榜单抓取热门话题，根据热度指数进行排序，并支持桌面界面或命令行两种方式查看结果。
 
-Here are some ideas to get you started:
+## 功能特点
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->https://cn.widgetstore.net/view/index.html?q=b83aa804654e31a8023e47297a96e964.2da1518365e5b31400bb7311743355d5
+- 📊 自动抓取百度实时热搜榜。
+- 🔢 将热度指数统一转换为数值，便于排序与后续分析。
+- 🖥️ 自带桌面应用，一键刷新即可查看当前热点，并支持双击打开原文链接。
+- 🔁 支持通过命令行参数控制返回条目数量及输出格式。
+- 🧱 提供基础组件，方便后续扩展到其他热点来源。
+
+## 快速开始
+
+1. 安装依赖：
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. 启动桌面程序：
+
+   ```bash
+   python -m trending_topics.app
+   ```
+
+   程序会自动抓取最新的百度实时热点，列表展示排行、热度与来源，选中后可在下方查看简介，双击任意行即可打开原始链接。
+
+3. 运行命令行工具（可选）：
+
+   ```bash
+   python -m trending_topics.cli --limit 20 --format table
+   ```
+
+   或以 JSON 格式输出：
+
+   ```bash
+   python -m trending_topics.cli --limit 10 --format json
+   ```
+
+## 模块说明
+
+- `trending_topics.collectors.BaiduHotSearchCollector`：负责从百度实时热点页面解析话题数据。
+- `trending_topics.ranking.rank_topics`：根据热度值对话题进行排序。
+- `trending_topics.app`：基于 Tkinter 的图形界面，适合希望“一键获取热点”的用户。
+- `trending_topics.cli`：简洁的 CLI 界面，可按需调整返回数量和输出格式。
+
+## 测试
+
+执行以下命令运行单元测试：
+
+```bash
+pytest
+```
+
+## 下一步可以做什么？
+
+- 增加更多热点源（例如微博热搜、知乎热榜等），并将结果合并展示。
+- 将结果写入数据库或推送到消息通知渠道，实现自动化的热点监控流程。
+- 将 CLI 扩展为 Web 服务，为团队提供可视化的热点追踪面板。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4>=4.12
+requests>=2.32

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,0 +1,17 @@
+from trending_topics.collectors import _parse_hot_value
+
+
+def test_parse_hot_value_plain_integer():
+    assert _parse_hot_value("12345") == 12345
+
+
+def test_parse_hot_value_with_wan_unit():
+    assert _parse_hot_value("1.2万") == 12000
+
+
+def test_parse_hot_value_with_yi_unit():
+    assert _parse_hot_value("0.5亿") == 50_000_000
+
+
+def test_parse_hot_value_invalid_input():
+    assert _parse_hot_value("未知") == 0

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,18 @@
+from trending_topics.models import TrendingTopic
+from trending_topics.ranking import rank_topics
+
+
+def make_topic(title: str, traffic: int) -> TrendingTopic:
+    return TrendingTopic(title=title, url=None, source="test", traffic=traffic)
+
+
+def test_rank_topics_descending():
+    topics = [make_topic("A", 100), make_topic("B", 50), make_topic("C", 200)]
+    ranked = rank_topics(topics)
+    assert [topic.title for topic in ranked] == ["C", "A", "B"]
+
+
+def test_rank_topics_ascending():
+    topics = [make_topic("A", 100), make_topic("B", 50), make_topic("C", 200)]
+    ranked = rank_topics(topics, descending=False)
+    assert [topic.title for topic in ranked] == ["B", "A", "C"]

--- a/trending_topics/__init__.py
+++ b/trending_topics/__init__.py
@@ -1,0 +1,27 @@
+"""Utilities for collecting and ranking trending topics from the web."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .models import TrendingTopic
+from .ranking import rank_topics
+
+__all__ = ["TrendingTopic", "rank_topics", "HotTopicsApp", "run"]
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .app import HotTopicsApp, run
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - import hook
+    if name in {"HotTopicsApp", "run"}:
+        from .app import HotTopicsApp, run  # type: ignore
+
+        globals()["HotTopicsApp"] = HotTopicsApp
+        globals()["run"] = run
+        return globals()[name]
+    raise AttributeError(f"module 'trending_topics' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(__all__)

--- a/trending_topics/app.py
+++ b/trending_topics/app.py
@@ -1,0 +1,208 @@
+"""Desktop application that fetches and displays trending topics."""
+
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+import webbrowser
+from tkinter import messagebox, ttk
+from typing import Iterable
+
+from .collectors import BaiduHotSearchCollector
+from .models import TrendingTopic
+from .ranking import rank_topics
+
+
+class HotTopicsApp:
+    """Tkinter based application to browse realtime hot topics."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("网络热点排行")
+        self.root.geometry("860x480")
+
+        self.collector = BaiduHotSearchCollector()
+        self._topics: list[TrendingTopic] = []
+
+        self.limit_var = tk.IntVar(value=20)
+        self.status_var = tk.StringVar(value="点击“刷新”获取最新话题")
+        self.description_var = tk.StringVar(value="")
+
+        self._build_widgets()
+
+    # ------------------------------------------------------------------ UI
+    def _build_widgets(self) -> None:
+        control_frame = ttk.Frame(self.root, padding=(12, 12))
+        control_frame.pack(fill=tk.X)
+
+        ttk.Label(control_frame, text="显示数量：").pack(side=tk.LEFT)
+        spinbox = ttk.Spinbox(
+            control_frame,
+            from_=5,
+            to=50,
+            increment=5,
+            textvariable=self.limit_var,
+            width=5,
+        )
+        spinbox.pack(side=tk.LEFT)
+
+        self.refresh_button = ttk.Button(
+            control_frame,
+            text="刷新热点",
+            command=self.refresh_topics,
+        )
+        self.refresh_button.pack(side=tk.LEFT, padx=(8, 0))
+
+        ttk.Label(control_frame, textvariable=self.status_var).pack(side=tk.LEFT, padx=16)
+
+        table_frame = ttk.Frame(self.root, padding=(12, 0, 12, 0))
+        table_frame.pack(fill=tk.BOTH, expand=True)
+        table_frame.columnconfigure(0, weight=1)
+        table_frame.rowconfigure(0, weight=1)
+
+        self.tree = ttk.Treeview(
+            table_frame,
+            columns=("rank", "title", "traffic", "source", "url"),
+            show="headings",
+            height=16,
+        )
+        self.tree.heading("rank", text="排名")
+        self.tree.heading("title", text="话题")
+        self.tree.heading("traffic", text="热度")
+        self.tree.heading("source", text="来源")
+        self.tree.heading("url", text="链接")
+
+        self.tree.column("rank", width=60, anchor=tk.CENTER)
+        self.tree.column("title", width=260)
+        self.tree.column("traffic", width=100, anchor=tk.CENTER)
+        self.tree.column("source", width=140)
+        self.tree.column("url", width=240)
+
+        self.tree.tag_configure("even", background="#f6f6f6")
+        self.tree.tag_configure("odd", background="white")
+
+        y_scroll = ttk.Scrollbar(table_frame, orient=tk.VERTICAL, command=self.tree.yview)
+        x_scroll = ttk.Scrollbar(table_frame, orient=tk.HORIZONTAL, command=self.tree.xview)
+        self.tree.configure(yscroll=y_scroll.set, xscroll=x_scroll.set)
+
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        y_scroll.grid(row=0, column=1, sticky="ns")
+        x_scroll.grid(row=1, column=0, sticky="ew")
+
+        self.tree.bind("<<TreeviewSelect>>", self._on_select_topic)
+        self.tree.bind("<Double-1>", self._on_open_link)
+
+        desc_frame = ttk.Frame(self.root, padding=(12, 0, 12, 12))
+        desc_frame.pack(fill=tk.X)
+        ttk.Label(desc_frame, text="话题简介：").pack(anchor=tk.W)
+        self.desc_label = ttk.Label(
+            desc_frame,
+            textvariable=self.description_var,
+            wraplength=820,
+            justify=tk.LEFT,
+        )
+        self.desc_label.pack(fill=tk.X)
+
+    # ---------------------------------------------------------------- events
+    def refresh_topics(self) -> None:
+        self.refresh_button.state(["disabled"])
+        self.status_var.set("正在获取热点...")
+        self.description_var.set("")
+        thread = threading.Thread(target=self._fetch_topics, daemon=True)
+        thread.start()
+
+    def _fetch_topics(self) -> None:
+        try:
+            limit = max(1, int(self.limit_var.get()))
+        except (TypeError, tk.TclError, ValueError):
+            limit = 20
+        try:
+            topics = rank_topics(self.collector.fetch(limit=limit))
+        except Exception as exc:  # pragma: no cover - UI feedback
+            self.root.after(0, self._handle_error, exc)
+        else:
+            self.root.after(0, self._update_topic_table, topics)
+
+    def _handle_error(self, exc: Exception) -> None:  # pragma: no cover - UI feedback
+        self.status_var.set("获取失败")
+        self._topics = []
+        self.refresh_button.state(["!disabled"])
+        messagebox.showerror("抓取失败", f"无法获取热点数据：{exc}")
+
+    def _update_topic_table(self, topics: Iterable[TrendingTopic]) -> None:
+        self._topics = list(topics)
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+
+        for index, topic in enumerate(self._topics, start=1):
+            self.tree.insert(
+                "",
+                "end",
+                iid=str(index),
+                values=(index, topic.title, topic.traffic, topic.source, topic.url or ""),
+                tags=("even" if index % 2 == 0 else "odd",),
+            )
+
+        self.status_var.set(f"已加载 {len(self._topics)} 条热点")
+
+        if self._topics:
+            first_item = self.tree.get_children()
+            if first_item:
+                self.tree.selection_set(first_item[0])
+                self.tree.focus(first_item[0])
+                self._on_select_topic()
+        else:
+            self.description_var.set("")
+
+        self.refresh_button.state(["!disabled"])
+
+    def _on_select_topic(self, event: tk.Event | None = None) -> None:
+        selection = self.tree.selection()
+        if not selection:
+            self.description_var.set("")
+            return
+
+        # The iid corresponds to the rank we inserted above.
+        item_id = selection[0]
+        try:
+            index = int(item_id) - 1
+        except ValueError:
+            self.description_var.set("")
+            return
+
+        if not hasattr(self, "_topics") or index >= len(self._topics):
+            self.description_var.set("")
+            return
+
+        topic = self._topics[index]
+        self.description_var.set(topic.description or "暂无简介")
+
+    def _on_open_link(self, event: tk.Event) -> None:  # pragma: no cover - user interaction
+        item_id = self.tree.identify_row(event.y)
+        if not item_id:
+            return
+
+        try:
+            index = int(item_id) - 1
+        except ValueError:
+            return
+
+        if index < 0 or index >= len(self._topics):
+            return
+
+        topic = self._topics[index]
+        if topic.url:
+            webbrowser.open_new_tab(topic.url)
+
+
+def run() -> None:
+    """Start the hot topic application."""
+
+    root = tk.Tk()
+    app = HotTopicsApp(root)
+    app.refresh_topics()
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run only
+    run()

--- a/trending_topics/cli.py
+++ b/trending_topics/cli.py
@@ -1,0 +1,76 @@
+"""Command line interface for the trending topic collector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from typing import Iterable, Sequence
+
+from .collectors import BaiduHotSearchCollector
+from .models import TrendingTopic
+from .ranking import rank_topics
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fetch and rank hot topics from Baidu.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of topics to display (default: 20).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="Output format (default: table).",
+    )
+    return parser
+
+
+def _format_table(topics: Sequence[TrendingTopic]) -> str:
+    headers = ["排名", "话题", "热度", "来源", "链接"]
+    rows = []
+    for index, topic in enumerate(topics, start=1):
+        rows.append(
+            [
+                str(index),
+                topic.title,
+                str(topic.traffic),
+                topic.source,
+                topic.url or "",
+            ]
+        )
+
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def format_row(row: Iterable[str]) -> str:
+        return " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+
+    lines = [format_row(headers), "-+-".join("-" * width for width in widths)]
+    lines.extend(format_row(row) for row in rows)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    collector = BaiduHotSearchCollector()
+    topics = rank_topics(collector.fetch(limit=args.limit))
+
+    if args.format == "json":
+        payload = [asdict(topic) for topic in topics]
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_format_table(topics))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/trending_topics/collectors.py
+++ b/trending_topics/collectors.py
@@ -1,0 +1,113 @@
+"""Collectors that fetch hot topics from different providers."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
+from .models import TrendingTopic
+
+_LOGGER = logging.getLogger(__name__)
+
+
+_TRAFFIC_UNIT_MAP = {
+    "万": 10_000,
+    "亿": 100_000_000,
+}
+
+
+def _parse_hot_value(raw_value: str) -> int:
+    """Convert Baidu's hot index text into an integer.
+
+    Baidu typically formats its hot index using Chinese units such as ``万``
+    (ten thousand) and ``亿`` (hundred million). The function also copes with
+    plain integer strings.
+    """
+
+    if not raw_value:
+        return 0
+
+    raw_value = raw_value.strip()
+
+    # Extract numeric part (possibly containing decimal points).
+    match = re.search(r"[\d.]+", raw_value)
+    if not match:
+        return 0
+
+    number = float(match.group())
+    unit = raw_value.replace(match.group(), "").strip()
+    multiplier = _TRAFFIC_UNIT_MAP.get(unit, 1)
+    traffic = int(number * multiplier)
+    return max(traffic, 0)
+
+
+@dataclass
+class BaiduHotSearchCollector:
+    """Collect trending topics from Baidu's realtime hot list."""
+
+    session: Optional[requests.Session] = None
+    timeout: float = 10.0
+
+    URL: str = "https://top.baidu.com/board?tab=realtime"
+    SOURCE: str = "baidu_realtime_hot"
+
+    def _get_session(self) -> requests.Session:
+        return self.session or requests.Session()
+
+    def fetch(self, *, limit: Optional[int] = None) -> List[TrendingTopic]:
+        """Fetch realtime hot topics from Baidu.
+
+        Parameters
+        ----------
+        limit:
+            Optional maximum number of topics to return. If ``None`` all
+            available topics are returned.
+        """
+
+        session = self._get_session()
+        response = session.get(self.URL, timeout=self.timeout)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        items: Iterable[Tag] = soup.select("div.category-wrap_iQLoo")
+
+        topics: List[TrendingTopic] = []
+        for idx, item in enumerate(items, start=1):
+            title_el = item.select_one("div.c-single-text-ellipsis")
+            if title_el is None:
+                _LOGGER.debug("Skipping topic %s without a title", idx)
+                continue
+
+            hot_el = item.select_one("div.hot-index_1Bl1a")
+            description_el = item.select_one("div.hot-desc_1m_jR")
+            link_el = item.select_one("a.title_dIF3B")
+
+            title = title_el.get_text(strip=True)
+            traffic = _parse_hot_value(hot_el.get_text(strip=True)) if hot_el else 0
+            description = description_el.get_text(strip=True) if description_el else None
+            if description:
+                description = re.sub(r"查看(更多|全部)>?", "", description).strip()
+            url = link_el["href"] if link_el and link_el.has_attr("href") else None
+
+            topics.append(
+                TrendingTopic(
+                    title=title,
+                    url=url,
+                    source=self.SOURCE,
+                    traffic=traffic,
+                    description=description,
+                )
+            )
+
+            if limit is not None and len(topics) >= limit:
+                break
+
+        return topics
+
+
+__all__ = ["BaiduHotSearchCollector"]

--- a/trending_topics/models.py
+++ b/trending_topics/models.py
@@ -1,0 +1,39 @@
+"""Data models used by the trending topic collector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(slots=True)
+class TrendingTopic:
+    """Represents a trending topic returned by an upstream provider.
+
+    Attributes
+    ----------
+    title:
+        The human readable title of the topic.
+    url:
+        A canonical URL that points to more information about the topic. Not all
+        providers supply URLs. ``None`` denotes that no URL is available.
+    source:
+        Name of the upstream source, for example ``"google_trends"``.
+    traffic:
+        A normalised integer that indicates the relative interest for this
+        topic. When the upstream source does not publish absolute numbers we
+        convert the supplied qualitative labels (e.g. ``"100K+"``) into rough
+        integers. Higher values mean higher interest.
+    description:
+        Optional free form text that describes the topic.
+    """
+
+    title: str
+    url: Optional[str]
+    source: str
+    traffic: int
+    description: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.traffic < 0:
+            raise ValueError("traffic must be a non-negative integer")

--- a/trending_topics/ranking.py
+++ b/trending_topics/ranking.py
@@ -1,0 +1,22 @@
+"""Ranking helpers for trending topics."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .models import TrendingTopic
+
+
+def rank_topics(topics: Iterable[TrendingTopic], *, descending: bool = True) -> List[TrendingTopic]:
+    """Return topics sorted by their traffic score.
+
+    Parameters
+    ----------
+    topics:
+        An iterable of :class:`~trending_topics.models.TrendingTopic` instances.
+    descending:
+        Whether to sort in descending order of traffic (default). If ``False``
+        the topics are sorted from least to most popular.
+    """
+
+    return sorted(topics, key=lambda topic: topic.traffic, reverse=descending)


### PR DESCRIPTION
## Summary
- add a Tkinter desktop application that fetches, ranks, and displays Baidu hot topics with sorting, link opening, and inline descriptions
- document the graphical interface alongside the CLI workflow in the README for quick usage
- expose the desktop application through the package init module with lazy loading to avoid unwanted GUI imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a79b6b1883208d9354536862e40a